### PR TITLE
fix(dates): [DateTimeUtils] Use short duration formats.

### DIFF
--- a/packages/dates/src/date-time-utils/DateTimeUtils.spec.ts
+++ b/packages/dates/src/date-time-utils/DateTimeUtils.spec.ts
@@ -413,11 +413,11 @@ test.each<
 );
 
 test('formatRelative(…)', () => {
-  expect(formatRelativeTime('2019-05-24')).toBe('7 hr. ago');
-  expect(formatRelativeTime('2019-05-24T05:00:00Z')).toBe('7 hr. ago');
-  expect(formatRelativeTime('2019-05-24T05:00:00-0000')).toBe('7 hr. ago');
-  expect(formatRelativeTime('2019-05-24T00:00:00-0500')).toBe('7 hr. ago');
-  expect(formatRelativeTime('2019-05-24T10:00:00+0500')).toBe('7 hr. ago');
+  expect(formatRelativeTime('2019-05-24')).toBe('7h ago');
+  expect(formatRelativeTime('2019-05-24T05:00:00Z')).toBe('7h ago');
+  expect(formatRelativeTime('2019-05-24T05:00:00-0000')).toBe('7h ago');
+  expect(formatRelativeTime('2019-05-24T00:00:00-0500')).toBe('7h ago');
+  expect(formatRelativeTime('2019-05-24T10:00:00+0500')).toBe('7h ago');
 });
 
 test.each<[NullableDateRangeInput, Record<DateFormat, DateTimeRange>]>([

--- a/packages/dates/src/date-time-utils/DateTimeUtils.ts
+++ b/packages/dates/src/date-time-utils/DateTimeUtils.ts
@@ -172,7 +172,10 @@ export function formatRelativeTime(
     const formatted = date.toRelative({ base, unit, style, round, padding });
 
     if (formatted) {
-      return formatted;
+      return formatted
+        .replace(/\ssec\./g, 's')
+        .replace(/\shr\./g, 'h')
+        .replace(/\smin\./g, 'm');
     }
   }
 

--- a/packages/dates/src/formatted-relative-time/FormattedRelativeTime.spec.tsx
+++ b/packages/dates/src/formatted-relative-time/FormattedRelativeTime.spec.tsx
@@ -30,13 +30,13 @@ describe('FormattedRelativeTime', () => {
 
     expect(container).toMatchInlineSnapshot(`
       <div>
-        in 0 sec.
-        14 sec. ago
-        in 45 sec.
-        13 min. ago
-        in 46 min.
-        7 hr. ago
-        in 16 hr.
+        in 0s
+        14s ago
+        in 45s
+        13m ago
+        in 46m
+        7h ago
+        in 16h
         4 days ago
         in 2 days
         23 days ago


### PR DESCRIPTION
Luxon uses short duration formats for `toRelative` method. However our designers have their own convention about formatting those dates. 

This PR includes small changes for those conventions. These changes based on following document https://www.notion.so/superdispatch/Displaying-Time-ab37baa8caeb48abb1f614081d854f6a